### PR TITLE
Stop evaluating positions post-ultimate-endangerment

### DIFF
--- a/src/mind.rs
+++ b/src/mind.rs
@@ -135,7 +135,7 @@ pub fn α_β_negamax_search(world: WorldState,
         if experienced_α >= β {
             break;
         }
-        if (20000.0 - experienced_α.abs()).abs() < 30.0 {
+        if (20000.0 - experienced_α.abs()).abs() < 1000.0 {
             break;
         };
     }


### PR DESCRIPTION
For performance reasons, it's very silly to cling so strictly to the
idea that one *must*, no matter what, evaluate exactly `n` levels deep,
no more, and no less. This leads to ridiculous situations such as
searching down a completely meaningless and exponentially large tree for
many minutes when one has already found a winning move.

Unfortunately the current situation on this commit is not really very
good. Leafline will happily find that there is a mate, short circuit,
and return you a move that is wildly circuitous, because they are
ordered with only preference for material advantage, and leafline does
not, for example, know about the 50 move rule, or run out of patience at
any time. So this is pretty silly: try running
`./target/release/leafline --depth 50 --from="7K/r7/1r6/8/8/8/8/7k b -"`
to witness it yourself.

Anyway, I think that the short circuiting is correct, and so this is its
own commit; unfortunately the work to make this playable is not actually
done.