### PR TITLE
Performance work

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -24,6 +24,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "fnv"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "fuchsia-zircon"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -57,6 +62,7 @@ version = "0.0.18"
 dependencies = [
  "ansi_term 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "argparse 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "itertools 0.4.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -276,6 +282,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum argparse 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "37bb99f5e39ee8b23b6e227f5b8f024207e8616f44aa4b8c76ecd828011667ef"
 "checksum bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "228047a76f468627ca71776ecdebd732a3423081fcf5125585bcd7c49886ce12"
 "checksum cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
+"checksum fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "2fad85553e09a6f881f739c29f0b00b0f01357c743266d478b68951ce23285f3"
 "checksum fuchsia-zircon 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2e9763c69ebaae630ba35f74888db465e49e259ba1bc0eda7d06f4a067615d82"
 "checksum fuchsia-zircon-sys 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
 "checksum itertools 0.4.19 (registry+https://github.com/rust-lang/crates.io-index)" = "c4a9b56eb56058f43dc66e58f40a214b2ccbc9f3df51861b63d51dec7b65bc3f"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -57,6 +57,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "lazy_static"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "leafline"
 version = "0.0.18"
 dependencies = [
@@ -64,6 +69,7 @@ dependencies = [
  "argparse 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "itertools 0.4.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "lru-cache 0.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -287,6 +293,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum fuchsia-zircon-sys 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
 "checksum itertools 0.4.19 (registry+https://github.com/rust-lang/crates.io-index)" = "c4a9b56eb56058f43dc66e58f40a214b2ccbc9f3df51861b63d51dec7b65bc3f"
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
+"checksum lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bc5729f27f159ddd61f4df6228e827e86643d4d3e7c32183cb30a1c08f604a14"
 "checksum libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)" = "76e3a3ef172f1a0b9a9ff0dd1491ae5e6c948b94479a3021819ba7d860c8645d"
 "checksum linked-hash-map 0.0.9 (registry+https://github.com/rust-lang/crates.io-index)" = "83f7ff3baae999fdf921cccf54b61842bb3b26868d50d02dff48052ebec8dd79"
 "checksum lock_api 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "775751a3e69bde4df9b38dd00a1b5d6ac13791e4223d4a0506577f0dd27cfb7a"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ rustc-serialize = "0.3"
 time = "0.1"
 twox-hash = "1.0"
 fnv = "1.0.3"
+lazy_static = "1.3.0"
 
 [profile.dev]
 opt-level = 2

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ parking_lot = {version = "0.6", features = ["nightly"]}
 rustc-serialize = "0.3"
 time = "0.1"
 twox-hash = "1.0"
+fnv = "1.0.3"
 
 [profile.dev]
 opt-level = 2

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,3 +20,4 @@ opt-level = 2
 
 [profile.release]
 lto = true
+debug = true

--- a/src/identity.rs
+++ b/src/identity.rs
@@ -48,19 +48,72 @@ pub struct Agent {
     pub job_description: JobDescription,
 }
 
+static ORANGE_AGENTS: [Agent; 6] = [
+    Agent {
+        team: Team::Orange,
+        job_description: JobDescription::Servant
+    },
+    Agent {
+        team: Team::Orange,
+        job_description: JobDescription::Pony
+    },
+    Agent {
+        team: Team::Orange,
+        job_description: JobDescription::Scholar
+    },
+    Agent {
+        team: Team::Orange,
+        job_description: JobDescription::Cop
+    },
+    Agent {
+        team: Team::Orange,
+        job_description: JobDescription::Princess
+    },
+    Agent {
+        team: Team::Orange,
+        job_description: JobDescription::Figurehead
+    },
+];
+
+
+static BLUE_AGENTS: [Agent; 6] = [
+    Agent {
+        team: Team::Blue,
+        job_description: JobDescription::Servant
+    },
+    Agent {
+        team: Team::Blue,
+        job_description: JobDescription::Pony
+    },
+    Agent {
+        team: Team::Blue,
+        job_description: JobDescription::Scholar
+    },
+    Agent {
+        team: Team::Blue,
+        job_description: JobDescription::Cop
+    },
+    Agent {
+        team: Team::Blue,
+        job_description: JobDescription::Princess
+    },
+    Agent {
+        team: Team::Blue,
+        job_description: JobDescription::Figurehead
+    },
+];
+
 impl Agent {
     pub fn new(team: Team, job_description: JobDescription) -> Self {
         Self { team, job_description }
     }
 
-    pub fn dramatis_personæ(team: Team) -> Vec<Agent> {
+    pub fn dramatis_personæ(team: Team) -> [Agent; 6] {
         // TODO: return in iterator
-        vec![Agent::new(team, JobDescription::Servant),
-             Agent::new(team, JobDescription::Pony),
-             Agent::new(team, JobDescription::Scholar),
-             Agent::new(team, JobDescription::Cop),
-             Agent::new(team, JobDescription::Princess),
-             Agent::new(team, JobDescription::Figurehead)]
+        match team {
+            Team::Orange => ORANGE_AGENTS,
+            Team::Blue => BLUE_AGENTS
+        }
     }
 
     pub fn to_preservation_rune(&self) -> char {

--- a/src/life.rs
+++ b/src/life.rs
@@ -411,7 +411,8 @@ impl WorldState {
         let mut rank = 7;
         let mut file = 0;
         let mut world = WorldState::new_except_empty();
-        let mut volumes = scan.split(' ');
+        let replaced = scan.replace("X", " ");
+        let mut volumes = replaced.split(' ');
         let positional_scan = volumes.next();
         for rune in positional_scan.unwrap().chars() {
             match rune {

--- a/src/life.rs
+++ b/src/life.rs
@@ -1033,28 +1033,6 @@ impl WorldState {
         self.princess_lookahead(moving_team, nihilistically, &mut premonitions);
         self.figurehead_lookahead(moving_team, nihilistically, &mut premonitions);
 
-        /*
-        let servant_premonitions = self.servant_lookahead(moving_team, nihilistically);
-        let pony_premonitions = self.pony_lookahead(moving_team, nihilistically);
-        let scholar_premonitions = self.scholar_lookahead(moving_team, nihilistically);
-        let cop_premonitions = self.cop_lookahead(moving_team, nihilistically);
-        let princess_premonitions = self.princess_lookahead(moving_team, nihilistically);
-        let figurehead_premonitions = self.figurehead_lookahead(moving_team, nihilistically);
-        let mut premonitions = Vec::with_capacity(
-            servant_premonitions.len() +
-            pony_premonitions.len() +
-            scholar_premonitions.len() +
-            cop_premonitions.len() +
-            princess_premonitions.len() +
-            figurehead_premonitions.len()
-        );
-        premonitions.extend(servant_premonitions);
-        premonitions.extend(pony_premonitions);
-        premonitions.extend(scholar_premonitions);
-        premonitions.extend(cop_premonitions);
-        premonitions.extend(princess_premonitions);
-        premonitions.extend(figurehead_premonitions);
-        */
         premonitions
     }
 
@@ -1128,6 +1106,7 @@ mod tests {
     // an arbitrarily chosen "complicated" looking position from a Kasparov
     // game
     static VISION: &'static str = "3q1rk1/2R1bppp/pP2p3/N2b4/1r6/4BP2/1P1Q2PP/R5K1 b - -";
+
 
     #[bench]
     fn benchmark_servant_lookahead(b: &mut Bencher) {

--- a/src/life.rs
+++ b/src/life.rs
@@ -525,9 +525,9 @@ impl WorldState {
     }
 
     pub fn occupying_affiliated_agent(&self, at: Locale, team: Team) -> Option<Agent> {
-        for agent in Agent::dramatis_personæ(team) {
-            if self.agent_to_pinfield_ref(agent).query(at) {
-                return Some(agent);
+        for agent in &Agent::dramatis_personæ(team) {
+            if self.agent_to_pinfield_ref(*agent).query(at) {
+                return Some(*agent);
             }
         }
         None
@@ -677,26 +677,26 @@ impl WorldState {
 
     fn subpredict(&self, premonitions: &mut Vec<Commit>, premonition: Commit) {
         if premonition.patch.concerns_servant_ascension() {
-            for ascended in Agent::dramatis_personæ(premonition.patch.star.team) {
+            for ascended in &Agent::dramatis_personæ(premonition.patch.star.team) {
                 if ascended.job_description == JobDescription::Servant ||
                    ascended.job_description == JobDescription::Figurehead {
                     continue;
                 }
                 let mut ascendency = premonition;
-                ascendency.ascension = Some(ascended);
+                ascendency.ascension = Some(*ascended);
                 let vessel_pinfield =
                     premonition.tree
                                .agent_to_pinfield_ref(premonition.patch.star)
                                .quench(premonition.patch.whither);
                 let ascended_pinfield = premonition.tree
-                                                   .agent_to_pinfield_ref(ascended)
+                                                   .agent_to_pinfield_ref(*ascended)
                                                    .alight(premonition.patch
                                                                       .whither);
                 ascendency.tree =
                     ascendency.tree
                               .except_replaced_subboard(premonition.patch.star,
                                                         vessel_pinfield)
-                              .except_replaced_subboard(ascended, ascended_pinfield);
+                              .except_replaced_subboard(*ascended, ascended_pinfield);
                 premonitions.push(ascendency);
             }
         } else {

--- a/src/life.rs
+++ b/src/life.rs
@@ -1132,41 +1132,55 @@ mod tests {
     #[bench]
     fn benchmark_servant_lookahead(b: &mut Bencher) {
         let ws = WorldState::reconstruct(VISION);
-        b.iter(|| ws.servant_lookahead(Team::Orange, false));
+        b.iter(|| {
+            let mut premonitions = Vec::new();
+            ws.servant_lookahead(Team::Orange, false, &mut premonitions)
+        });
     }
 
     #[bench]
     fn benchmark_pony_lookahead(b: &mut Bencher) {
         let ws = WorldState::reconstruct(VISION);
-        b.iter(|| ws.pony_lookahead(Team::Orange, false));
+        b.iter(|| {
+            let mut premonitions = Vec::new();
+            ws.pony_lookahead(Team::Orange, false, &mut premonitions)
+        });
     }
 
     #[bench]
     fn benchmark_scholar_lookahead(b: &mut Bencher) {
         let ws = WorldState::reconstruct(VISION);
-        b.iter(|| ws.scholar_lookahead(Team::Orange, false));
+        b.iter(|| {
+            let mut premonitions = Vec::new();
+            ws.scholar_lookahead(Team::Orange, false, &mut premonitions)
+        });
     }
 
     #[bench]
     fn benchmark_cop_lookahead(b: &mut Bencher) {
         let ws = WorldState::reconstruct(VISION);
-        ws.cop_lookahead(Team::Orange, false);
-        ws.cop_lookahead(Team::Orange, false);
-        ws.cop_lookahead(Team::Orange, false);
-        ws.cop_lookahead(Team::Orange, false);
-        b.iter(|| ws.cop_lookahead(Team::Orange, false));
+        b.iter(|| {
+            let mut premonitions = Vec::new();
+            ws.cop_lookahead(Team::Orange, false, &mut premonitions)
+        });
     }
 
     #[bench]
     fn benchmark_princess_lookahead(b: &mut Bencher) {
         let ws = WorldState::reconstruct(VISION);
-        b.iter(|| ws.princess_lookahead(Team::Orange, false));
+        b.iter(|| {
+            let mut premonitions = Vec::new();
+            ws.princess_lookahead(Team::Orange, false, &mut premonitions)
+        });
     }
 
     #[bench]
     fn benchmark_figurehead_lookahead(b: &mut Bencher) {
         let ws = WorldState::reconstruct(VISION);
-        b.iter(|| ws.figurehead_lookahead(Team::Orange, false));
+        b.iter(|| {
+            let mut premonitions = Vec::new();
+            ws.figurehead_lookahead(Team::Orange, false, &mut premonitions)
+        });
     }
 
     #[bench]
@@ -1237,25 +1251,30 @@ mod tests {
     #[test]
     fn concerning_castling_availability() {
         let mut ws = WorldState::reconstruct("8/8/4k3/8/8/8/8/4K2R w K -");
-        let mut prems = ws.service_lookahead(Team::Orange, false);
+        let mut prems = Vec::new();
+        ws.service_lookahead(Team::Orange, false, &mut prems);
         assert_eq!(1, prems.len());
 
+        prems.clear();
         ws = WorldState::reconstruct("8/8/4k3/8/8/8/8/R3K2R w KQ -");
-        prems = ws.service_lookahead(Team::Orange, false);
+        ws.service_lookahead(Team::Orange, false, &mut prems);
         assert_eq!(2, prems.len());
 
+        prems.clear();
         ws = WorldState::reconstruct("8/8/4k3/8/8/8/8/R3KN1R w Q -");
-        prems = ws.service_lookahead(Team::Orange, false);
+        ws.service_lookahead(Team::Orange, false, &mut prems);
         assert_eq!(1, prems.len());
 
+        prems.clear();
         ws = WorldState::reconstruct("8/8/4k3/8/8/4b3/8/R3KN1R w Q -");
         // can't move into endangerment
-        prems = ws.service_lookahead(Team::Orange, false);
+        ws.service_lookahead(Team::Orange, false, &mut prems);
         assert_eq!(0, prems.len());
 
+        prems.clear();
         ws = WorldState::reconstruct("8/8/4k3/8/b7/8/8/R3KN1R w Q - 0 1");
         // can't move through endangerment, either!
-        prems = ws.service_lookahead(Team::Orange, false);
+        ws.service_lookahead(Team::Orange, false, &mut prems);
         assert_eq!(0, prems.len());
     }
 
@@ -1263,7 +1282,8 @@ mod tests {
     fn concerning_castling_actually_working() {
         let ws = WorldState::reconstruct("8/8/4k3/8/8/8/8/4K2R w K -");
         assert!(ws.orange_east_service_eligibility());
-        let prems = ws.service_lookahead(Team::Orange, false);
+        let mut prems = Vec::new();
+        ws.service_lookahead(Team::Orange, false, &mut prems);
         assert_eq!(1, prems.len());
         assert_eq!(false, prems[0].tree.orange_east_service_eligibility());
         assert_eq!("8/8/4k3/8/8/8/8/5RK1 b - -", prems[0].tree.preserve());
@@ -1273,7 +1293,8 @@ mod tests {
     fn concerning_castling_out_of_check() {
         let ws = WorldState::reconstruct("8/8/4k3/8/4r3/8/8/4K2R w K -");
         assert!(ws.orange_east_service_eligibility());
-        let prems = ws.service_lookahead(Team::Orange, false);
+        let mut prems = Vec::new();
+        ws.service_lookahead(Team::Orange, false, &mut prems);
         assert_eq!(0, prems.len());
     }
 
@@ -1288,7 +1309,8 @@ mod tests {
             worldstate.except_replaced_subboard(Agent::new(Team::Orange,
                                                            JobDescription::Servant),
                                                 derived_subfield);
-        let premonitions = worldstate.servant_lookahead(Team::Orange, true);
+        let mut premonitions = Vec::new();
+        worldstate.servant_lookahead(Team::Orange, true, &mut premonitions);
         assert!(premonitions.iter().all(|p| {
             p.patch.whither == Locale::from_algebraic("a8")
         }));
@@ -1326,7 +1348,8 @@ mod tests {
     #[test]
     fn test_orange_servant_lookahead_from_original_position() {
         let state = WorldState::new();
-        let premonitions = state.servant_lookahead(Team::Orange, false);
+        let mut premonitions = Vec::new();
+        state.servant_lookahead(Team::Orange, false, &mut premonitions);
         assert_eq!(16, premonitions.len());
         // although granted that a more thorough test would actually
         // say something about the nature of the positions, rather than
@@ -1336,7 +1359,8 @@ mod tests {
     #[test]
     fn test_orange_pony_lookahead_from_original_position() {
         let state = WorldState::new();
-        let premonitions = state.pony_lookahead(Team::Orange, false);
+        let mut premonitions = Vec::new();
+        state.pony_lookahead(Team::Orange, false, &mut premonitions);
         assert_eq!(4, premonitions.len());
         let collected = premonitions.iter()
                                     .map(|p| p.tree.orange_ponies.to_locales())
@@ -1360,7 +1384,8 @@ mod tests {
         world.blue_princesses =
             world.blue_princesses
                  .alight(Locale::from_algebraic("g3"));
-        let premonitions = world.scholar_lookahead(Team::Orange, false);
+        let mut premonitions = Vec::new();
+        world.scholar_lookahead(Team::Orange, false, &mut premonitions);
         let expected = vec!["d2", "f2", "g3"]
                            .iter()
                            .map(|a| Locale::from_algebraic(*a))
@@ -1444,13 +1469,13 @@ mod tests {
         assert_eq!(None, second_commit.hospitalization);
 
         let precrucial_state = second_commit.tree;
-        let available_stunnings = precrucial_state.servant_lookahead(Team::Orange,
-                                                                     false)
-                                                  .into_iter()
-                                                  .filter(|p| {
-                                                      p.hospitalization.is_some()
-                                                  })
-                                                  .collect::<Vec<_>>();
+        let mut premonitions = Vec::new();
+        precrucial_state.servant_lookahead(Team::Orange, false, &mut premonitions);
+        let available_stunnings = premonitions.into_iter()
+                                              .filter(|p| {
+                                                  p.hospitalization.is_some()
+                                              })
+                                              .collect::<Vec<_>>();
         assert_eq!(1, available_stunnings.len());
         assert_eq!(blue_servant_agent,
                    available_stunnings[0].hospitalization.unwrap());
@@ -1575,8 +1600,9 @@ mod tests {
     #[test]
     fn concerning_passing_by_in_action() {
         let world = WorldState::reconstruct("rnbqkbnr/ppp2ppp/4p3/3pP3/8/8/PPPP1PPP/RNBQKBNR w KQkq d6 0 3");
-        let premonitions = world.servant_lookahead(Team::Orange, false)
-                                .into_iter()
+        let mut premonitions = Vec::new();
+        world.servant_lookahead(Team::Orange, false, &mut premonitions);
+        premonitions = premonitions.into_iter()
                                 .filter(|p| {
                                     p.patch.whence == Locale::from_algebraic("e5")
                                 })

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,6 +17,7 @@ extern crate parking_lot;
 extern crate rustc_serialize;
 extern crate time;
 extern crate twox_hash;
+extern crate fnv;
 
 
 #[macro_use] mod sorceries;

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,6 +19,8 @@ extern crate time;
 extern crate twox_hash;
 extern crate fnv;
 
+#[macro_use] extern crate lazy_static;
+
 
 #[macro_use] mod sorceries;
 mod space;

--- a/src/mind.rs
+++ b/src/mind.rs
@@ -153,16 +153,16 @@ fn mmv_lva_heuristic(commit: &Commit) -> f32 {
 }
 
 fn order_movements_heuristically(commits: &mut Vec<Commit>) {
-    commits.sort_by(|a, b| {
+    commits.sort_unstable_by(|a, b| {
         mmv_lva_heuristic(b)
             .partial_cmp(&mmv_lva_heuristic(a))
             .unwrap_or(Ordering::Equal)
     });
 }
 
-fn order_movements_intuitively(experience: &HashMap<Patch, u32>,
-    commits: &mut Vec<Commit>) {
-    commits.sort_by(|a, b| {
+fn order_movements_intuitively(
+        experience: &HashMap<Patch, u32>, commits: &mut Vec<Commit>) {
+    commits.sort_unstable_by(|a, b| {
         let a_feels = experience.get(&a.patch);
         let b_feels = experience.get(&b.patch);
         b_feels.cmp(&a_feels)
@@ -380,7 +380,7 @@ pub fn potentially_timebound_kickoff(
         debug!("waiting for {} of {} first-movement search threads",
                time_radios.len(), premonitions.len())
     }
-    forecasts.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(Ordering::Equal));
+    forecasts.sort_unstable_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(Ordering::Equal));
     Some(forecasts)
 }
 

--- a/src/mind.rs
+++ b/src/mind.rs
@@ -341,7 +341,7 @@ pub fn potentially_timebound_kickoff(
         let experience = intuition_bank.lock();
         order_movements_intuitively(&experience, &mut premonitions)
     }
-    let mut forecasts = Vec::new();
+    let mut forecasts = Vec::with_capacity(40);
     let mut time_radios: Vec<(Commit, mpsc::Receiver<Lodestar>)> = Vec::new();
     for &premonition in &premonitions {
         let travel_memory_bank = memory_bank.clone();

--- a/src/mind.rs
+++ b/src/mind.rs
@@ -53,10 +53,10 @@ pub fn score(world: WorldState) -> f32 {
     valuation += REWARD_FOR_INITIATIVE * orientation(world.initiative);
 
     for team in Team::league() {
-        for agent in Agent::dramatis_personæ(team) {
-            valuation += f32::from(world.agent_to_pinfield_ref(agent)
+        for agent in &Agent::dramatis_personæ(team) {
+            valuation += f32::from(world.agent_to_pinfield_ref(*agent)
                                    .pincount()) *
-                figurine_valuation(agent);
+                figurine_valuation(*agent);
         }
         // breadth of scholarship bonus
         if world.agent_to_pinfield_ref(Agent {

--- a/src/space.rs
+++ b/src/space.rs
@@ -129,7 +129,7 @@ impl Pinfield {
     }
 
     pub fn to_locales(&self) -> Vec<Locale> {
-        let mut locales = Vec::new();
+        let mut locales = Vec::with_capacity(8);
         let Pinfield(bits) = *self;
         let mut bitfield = 1u64;
         for rank in 0..8 {

--- a/src/space.rs
+++ b/src/space.rs
@@ -119,6 +119,8 @@ impl Pinfield {
     }
 
     pub fn transit(&self, departure: Locale, destination: Locale) -> Pinfield {
+        // empirically, pulling function calls out of this and replacing
+        // them with bit manipulation directly doesnt help.
         self.quench(departure).alight(destination)
     }
 
@@ -169,7 +171,7 @@ impl Pinfield {
 #[cfg(test)]
 mod tests {
     extern crate test;
-    use self::test::Bencher;
+    use self::test::{Bencher, black_box};
     use super::{Locale, Pinfield};
 
     static ALGEBRAICS: [&'static str; 64] = [
@@ -192,6 +194,20 @@ mod tests {
         }
 
         b.iter(|| stage.to_locales());
+    }
+
+    #[bench]
+    fn benchmark_transit(b: &mut Bencher) {
+        let mut stage = Pinfield(0);
+        let from = Locale::new(1, 3);
+        let to = Locale::new(2, 5);
+        stage = stage.alight(from);
+
+        b.iter(|| {
+            for _ in 0..10000 {
+                black_box(stage.transit(from, to));
+            }
+        });
     }
 
     #[test]

--- a/src/space.rs
+++ b/src/space.rs
@@ -8,6 +8,7 @@ static INDEX_TO_FILE_NAME: [char; 8] = [
     'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h'
 ];
 
+
 impl Locale {
     pub fn new(rank: u8, file: u8) -> Self {
         Self { rank, file }


### PR DESCRIPTION
i'm mostly stumped on how to squeeze any more speed out of this now, with the exception of rethinking the threading a lot, which sounds hard. but it should be quicker now!

compared to the branch this is intending to follow, im seeing `./leafline --correspond --depth 5 --from 'rnbqkbnr/pp1p1ppp/2p5/4P3/2P5/8/PP2PPPP/RNBQKBNR b KQkq - 0 3'` all the way down to about 6s (from 13); depth 6 now takes about a minute (from >2).