### PR TITLE
don't save space in correspondence postcards

### DIFF
--- a/src/life.rs
+++ b/src/life.rs
@@ -2,7 +2,7 @@
 use std::default::Default;
 use std::fmt;
 
-use space::{Locale, Pinfield, ORANGE_FIGUREHEAD_START, BLUE_FIGUREHEAD_START};
+use space::{Locale, RelaxedLocale, Pinfield, ORANGE_FIGUREHEAD_START, BLUE_FIGUREHEAD_START};
 use identity::{Agent, JobDescription, Team};
 use motion::{FIGUREHEAD_MOVEMENT_TABLE, PONY_MOVEMENT_TABLE};
 use ansi_term::Colour as Color;
@@ -17,6 +17,23 @@ pub struct Patch {
     pub star: Agent,
     pub whence: Locale,
     pub whither: Locale,
+}
+
+#[derive(Eq,PartialEq,Debug,Copy,Clone,Hash,RustcEncodable,RustcDecodable)]
+pub struct TransitPatch {
+    pub star: Agent,
+    pub whence: RelaxedLocale,
+    pub whither: RelaxedLocale,
+}
+
+impl From<Patch> for TransitPatch {
+    fn from(patch: Patch) -> Self {
+        Self {
+            star: patch.star,
+            whence: patch.whence.into(),
+            whither: patch.whither.into(),
+        }
+    }
 }
 
 impl Patch {

--- a/src/main.rs
+++ b/src/main.rs
@@ -45,7 +45,7 @@ use rustc_serialize::json;
 use time::{Duration, get_time};
 
 use identity::{Agent, Team};
-use life::{Commit, Patch, WorldState};
+use life::{Commit, Patch, TransitPatch, WorldState};
 use mind::{Variation, fixed_depth_sequence_kickoff, iterative_deepening_kickoff,
            kickoff, pagan_variation_format, Memory};
 use substrate::memory_free;
@@ -182,11 +182,11 @@ fn forecast<T: 'static + Memory>(world: WorldState, bound: LookaheadBound, déj�
 #[derive(RustcEncodable, RustcDecodable)]
 struct Postcard {
     world: String,
-    patch: Patch,
+    patch: TransitPatch,
     hospitalization: Option<Agent>,
     thinking_time: u64,
     depth: u8,
-    counterreplies: Vec<Patch>,
+    counterreplies: Vec<TransitPatch>,
     rosetta_stone: String,
 }
 
@@ -211,7 +211,7 @@ fn correspondence(reminder: &str, bound: LookaheadBound, déjà_vu_bound: f32)
         let counterreplies = determination.tree
                                           .lookahead()
                                           .iter()
-                                          .map(|c| c.patch)
+                                          .map(|c| TransitPatch::from(c.patch))
                                           .collect::<Vec<_>>();
         if counterreplies.is_empty() {
             if determination.tree.in_critical_endangerment(Team::Orange) {
@@ -225,7 +225,7 @@ fn correspondence(reminder: &str, bound: LookaheadBound, déjà_vu_bound: f32)
         }
         let postcard = Postcard {
             world: determination.tree.preserve(),
-            patch: determination.patch,
+            patch: TransitPatch::from(determination.patch),
             hospitalization: determination.hospitalization,
             thinking_time: sidereal.num_milliseconds() as u64,
             depth,

--- a/src/space.rs
+++ b/src/space.rs
@@ -3,6 +3,20 @@ pub struct Locale {
     rank_and_file: u8,
 }
 
+#[derive(Eq,PartialEq,Debug,Copy,Clone,Hash,RustcEncodable,RustcDecodable)]
+pub struct RelaxedLocale {
+    rank: u8,
+    file: u8,
+}
+
+// A less-compressed representation of a Locale, for compatibility with the
+// legacy web client
+impl From<Locale> for RelaxedLocale {
+    fn from(locale: Locale) -> Self {
+        Self { rank: locale.rank(), file: locale.file() }
+    }
+}
+
 pub const ORANGE_FIGUREHEAD_START: Locale = Locale { rank_and_file: (0 << 4) | 4 };
 pub const BLUE_FIGUREHEAD_START: Locale = Locale { rank_and_file: (7 << 4) | 4 };
 


### PR DESCRIPTION
The space-saving measures in c04afe38a1 broke the web client. (It was possible to make the first move, but it got confused immediately thereafter because the client couldn't understand the compressed `rank_and_file` field now being sent from the game engine.) I'm less afraid of editing five-year-old Rust than JavaScript, so let's slap in some `From`/`Into` conversions to make the JSON output be the way it used to rather than updating the client.